### PR TITLE
修正域名正则不支持端口

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ app.use(express.compress());
 app.use('/v1', function (req, res, next) {
   // 检查来源自动支持Ajax跨域访问
   if (req.get('referrer')) {
-    var host = req.get('referrer').match(/:\/\/([\w0-9\-_\.]+?)\//)[1];
+    var host = req.get('referrer').match(/:\/\/([\w\.\-]+)/)[1];
 
     if (/^(([\w0-9\-_\.]+?)\.)?(staticfile\.org|app\.com|localhost)$/.test(host)) {
       res.header({


### PR DESCRIPTION
jekyll 没法直接调试

```
'http://localhost1:4000'.match(/:\/\/([\w\.\-]+)/)
["://localhost1", "localhost1"]
'http://localhost1:4000'.match(/:\/\/([\w0-9\-_\.]+?)\//)
null
```

正则来自 https://github.com/tg123/chrome-hostadmin/blob/master/container/chrome/container.js#L32
